### PR TITLE
fixed \endif to \fi

### DIFF
--- a/graphicscache.dtx
+++ b/graphicscache.dtx
@@ -388,7 +388,7 @@
         >> setdistillerparams'
         -f graphicscache/graphicscacheout.pdf || rm \graphicscache@output
       }%
-    \endif
+    \fi
   \else
     \message{Direct}%
     \ifwindows
@@ -399,7 +399,7 @@
       \immediate\write18{
         cp graphicscache/graphicscacheout.pdf \graphicscache@output
       }%
-    \endif
+    \fi
   \fi
 }
 %    \end{macrocode}


### PR DESCRIPTION
The first compilation of a LaTeX file always causes an "Undefined control sequence" error.
 This PR fixes the compilation error.

```
Rendering 75EF00D60D13AADAD8CD07C32FE573CE: left-fig.jpg with args: width=34.50
21pt (master file) standalone method With compression: DCTEncode
! Undefined control sequence.
\graphicscache@dorender ...cscache@output }\endif 
                                                  \else \message {Direct}\if...
l.13 ...graphics[width=\figurewidth]{left-fig.jpg}
```