### PR TITLE
release.sh: make sure included files are unique

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -50,7 +50,7 @@ echo '\makeatletter\def\graphicscache@inhibit{true}\makeatother' > submission.te
 cat submission.tex.orig >> submission.tex
 pdflatex -interaction nonstopmode -recorder submission.tex
 
-FILES=$(grep "^INPUT" submission.fls | cut -d ' ' --complement -f 1 | grep -v '^/' | grep -v 'submission\..*')
+FILES=$(grep "^INPUT" submission.fls | cut -d ' ' --complement -f 1 | grep -v '^/' | grep -v 'submission\..*' | sort | uniq)
 FILES="$FILES submission.tex"
 
 if [[ -e submission.bbl ]]; then


### PR DESCRIPTION
It seems in some situations latex will output a used file more than once, and tar will actually pack it more than once, leading to extraction errors later on.