### PR TITLE
CI: add Ubuntu 18.04, fix graphics.sty version check

### DIFF
--- a/.github/actions/ubuntu18/Dockerfile
+++ b/.github/actions/ubuntu18/Dockerfile
@@ -1,0 +1,5 @@
+FROM xqms/ubuntu_texlive:18.04
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+

--- a/.github/actions/ubuntu18/action.yml
+++ b/.github/actions/ubuntu18/action.yml
@@ -1,0 +1,6 @@
+name: "ubuntu20"
+description: "Compile & test graphicscache on Ubuntu 20.04"
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+

--- a/.github/actions/ubuntu18/entrypoint.sh
+++ b/.github/actions/ubuntu18/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+echo "::group::Compiling graphicscache"
+latex -interaction=nonstopmode graphicscache.ins
+pdflatex -interaction=nonstopmode graphicscache.dtx
+echo "::endgroup::"
+
+(
+cd example
+
+echo "::group::Compiling example using pdflatex"
+TEXINPUTS=..: pdflatex -interaction=nonstopmode paper
+echo "::endgroup::"
+
+echo "::group::Compiling example using lualatex"
+rm -f paper.aux
+TEXINPUTS=..: lualatex -interaction=nonstopmode paper
+echo "::endgroup::"
+)
+
+echo "::group::Creating CTAN package"
+ctanify --pkgname=graphicscache graphicscache.ins graphicscache.pdf README.md
+echo "::endgroup::"
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,14 @@ jobs:
       uses: actions/checkout@v2
     - name: Compile and test
       uses: ./.github/actions/ubuntu16
+  ubuntu18:
+    runs-on: ubuntu-latest
+    name: Test on Ubuntu 18.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Compile and test
+      uses: ./.github/actions/ubuntu18
   ubuntu20:
     runs-on: ubuntu-latest
     name: Test on Ubuntu 20.04

--- a/graphicscache.dtx
+++ b/graphicscache.dtx
@@ -467,7 +467,7 @@
   \begingroup
   \global\graphicscache@existstrue
   \let\input@path\Ginput@path
-  \ltx@ifpackagelater{graphics}{2017/06/25}{%
+  \ltx@ifpackagelater{graphics}{2017/06/26}{%
     \set@curr@file{#1}%
     \expandafter\filename@parse\expandafter{\@curr@file}%
     \ifx\filename@ext\Gin@gzext
@@ -488,7 +488,7 @@
       \fi}%
   \else
     \Gin@getbase{\Gin@sepdefault\filename@ext}%
-    \ltx@ifpackagelater{graphics}{2017/06/25}{%
+    \ltx@ifpackagelater{graphics}{2017/06/26}{%
       \ifx\Gin@ext\relax
       \let\Gin@savedbase\filename@base
       \let\Gin@savedext\filename@ext


### PR DESCRIPTION
Some users report problems on Ubuntu 18.04, so we should test that as well.

The CI uncovered a problem with the `graphics.sty` version check, which is now fixed.