### PR TITLE
Remove .setpdfwrite instruction from gs command

### DIFF
--- a/graphicscache.dtx
+++ b/graphicscache.dtx
@@ -365,7 +365,7 @@
         -dCompatibilityLevel=1.4
         -dPDFSETTINGS=/prepress
         -dNOPAUSE -dQUIET -dBATCH
-        -c ".setpdfwrite <<
+        -c "<<
           /AutoFilterColorImages false
           /EncodeColorImages true
           /ColorImageFilter /\graphicscache@compress@mode\space
@@ -386,7 +386,7 @@
         -dCompatibilityLevel=1.4
         -dPDFSETTINGS=/prepress
         -dNOPAUSE -dQUIET -dBATCH
-        -c '.setpdfwrite <<
+        -c '<<
           /AutoFilterColorImages false
           /EncodeColorImages true
           /ColorImageFilter /\graphicscache@compress@mode\space


### PR DESCRIPTION
This directive has been deprecated in GhostScript 9.50 and removed in GhostScript 9.54.

See https://www.ghostscript.com/doc/9.54.0/History9.htm

This fixes #18.