### PR TITLE
Fix bug in gs autodetection

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
           graphicscache.pdf
           graphicscache.sty
   windows_miktex:
-    runs-on: windows-latest
+    runs-on: windows-2019
     name: Test on Windows using MikTeX
     steps:
     - name: Checkout
@@ -41,7 +41,7 @@ jobs:
     - name: Compile and test
       uses: ./.github/actions/windows
   windows_texlive:
-    runs-on: windows-latest
+    runs-on: windows-2019
     name: Test on Windows using TeX Live
     steps:
     - name: Checkout

--- a/example/paper.tex
+++ b/example/paper.tex
@@ -18,7 +18,13 @@
 
 \section{}
 
+\begin{figure}
 \includegraphics[height=5cm,clip,trim=100 0 100 0]{myimage}
+\end{figure}
+
+\begin{figure}
+\includegraphics[height=6cm,clip,trim=100 0 100 0]{myimage}
+\end{figure}
 
 \end{document}
 

--- a/example/test.bash
+++ b/example/test.bash
@@ -33,7 +33,7 @@ ls -lha paper_*.pdf
 function check_much_smaller_than {
     size1=$(stat --printf="%s" $1)
     size2=$(stat --printf="%s" $2)
-    ok=$(( size1 < (size2/2)))
+    ok=$(( size1 < (size2*3/4)))
     if [[ $ok -ne 1 ]]; then
         echo "FAIL: File $1 is not much smaller than $2 ($size1 vs $size2)!"
         exit 1

--- a/example/test.ps1
+++ b/example/test.ps1
@@ -51,7 +51,7 @@ function CheckMuchSmallerThan {
     )
     $size1 = (Get-Item $file1).length
     $size2 = (Get-Item $file2).length
-    $halfSize2 = $size2 / 2
+    $sizeThreshold = $size2 * 3 / 4
     if($size1 -lt $halfSize2)
     {
         echo "OK: $file1 is much smaller than $file2."

--- a/example/test.ps1
+++ b/example/test.ps1
@@ -52,13 +52,13 @@ function CheckMuchSmallerThan {
     $size1 = (Get-Item $file1).length
     $size2 = (Get-Item $file2).length
     $sizeThreshold = $size2 * 3 / 4
-    if($size1 -lt $halfSize2)
+    if($size1 -lt $sizeThreshold)
     {
         echo "OK: $file1 is much smaller than $file2."
     }
     else
     {
-        throw "FAIL: File $1 is not much smaller than $2 ($size1 vs $size2)!"
+        throw "FAIL: File $1 is not much smaller than $2 ($size1 vs $size2, threshold $sizeThreshold)!"
     }
 }
 

--- a/graphicscache.dtx
+++ b/graphicscache.dtx
@@ -379,7 +379,7 @@
         \graphicscache@callgswithname{\cmd}%
         \IfFileExists{\graphicscache@output}{%
             \message{Found a working ghostscript called '\cmd'.}%
-            \global\def\graphicscache@gscommand{\cmd}%
+            \global\edef\graphicscache@gscommand{\cmd}%
             \breakforeach
         }{}%
       }%

--- a/graphicscache.dtx
+++ b/graphicscache.dtx
@@ -375,10 +375,10 @@
   \else
     \@ifundefined{graphicscache@gscommand}{%
       \foreach \cmd in {rungs,gs,mgs} {%
-        \message{Trying \cmd\space to call ghostscript...^^J}%
+        \PackageInfo{graphicscache}{Trying \cmd\space to call ghostscript...^^J}%
         \graphicscache@callgswithname{\cmd}%
         \IfFileExists{\graphicscache@output}{%
-            \message{Found a working ghostscript called '\cmd'.}%
+            \PackageInfo{graphicscache}{Found a working ghostscript called '\cmd'.}%
             \global\edef\graphicscache@gscommand{\cmd}%
             \breakforeach
         }{}%
@@ -388,6 +388,7 @@
         \graphicscache@gsnotavailabletrue
       }{}%
     }{%
+      \PackageInfo{graphicscache}{Calling gs with name '\graphicscache@gscommand'^^J}
       \graphicscache@callgswithname{\graphicscache@gscommand}
     }%
   \fi
@@ -399,7 +400,7 @@
 %    to cross-platform support.
 %    \begin{macrocode}
 \newcommand{\graphicscache@dorender}{%
-  \message{Rendering \graphicscache@outputhash: \graphicscache@fname\space with args: \graphicscache@graphicsargs\space (master file)}%
+  \PackageInfo{graphicscache}{Rendering \graphicscache@outputhash: \graphicscache@fname\space with args: \graphicscache@graphicsargs\space (master file)}%
   \ifwindows
     \immediate\write18{md "\graphicscache@cachedir" 2>NUL}%
   \else
@@ -440,10 +441,10 @@
 % file.
 %    \begin{macrocode}
   \ifgraphicscache@compress
-    \message{With compression: \graphicscache@compress@mode}%
+    \PackageInfo{graphicscache}{With compression: \graphicscache@compress@mode}%
     \graphicscache@callgs
   \else
-    \message{Direct}%
+    \PackageInfo{graphicscache}{Direct}%
     \ifwindows
       \immediate\write18{
         copy \graphicscache@cachedir\string\graphicscacheout.pdf \graphicscache@output
@@ -478,7 +479,7 @@
     \filemodcmp{\graphicscache@fname}{\graphicscache@output}{% input is newer
       \graphicscache@dorender%
     }{% Output is newer
-      \message{Already have \graphicscache@outputhash: \graphicscache@fname}%
+      \PackageInfo{graphicscache}{Already have \graphicscache@outputhash: \graphicscache@fname}%
     }%
 %    \end{macrocode}
 % If it still does not exist, we are likely in a strange environment
@@ -601,7 +602,7 @@
     \edef\graphicscache@outputhash{\pdf@mdfivesum{\graphicscache@options\graphicscache@graphicsargs\graphicscache@hashedname}}%
     \edef\graphicscache@output{\graphicscache@cachedir/\graphicscache@outputhash.pdf}%
     \ifgraphicscache@listing
-      \message{graphicscache: includegraphics\{#2\} => \graphicscache@output}%
+      \PackageInfo{graphicscache}{graphicscache: includegraphics\{#2\} => \graphicscache@output}%
       \immediate\write\graphicscache@listout{#2 \graphicscache@fname\space \graphicscache@output}%
     \fi
     \graphicscache@work


### PR DESCRIPTION
This happens when multiple *different* graphics are included, which the unit tests did not cover. Now they do.